### PR TITLE
fix(key_handler): comment out bad line

### DIFF
--- a/key_handler.js
+++ b/key_handler.js
@@ -22,7 +22,7 @@ function keyDownTextField(e) {
         if (e.ctrlKey && e.shiftKey && text != "") {
             e.preventDefault();
 
-            ifdiv.getAttribute("role") == "textbox"
+            // ifdiv.getAttribute("role") == "textbox"
             div.value = div.value.trim();
             div.value = div.value.substring(div.value.lastIndexOf(text), (div.value - text.length) );
             div.value += emoji + " ";


### PR DESCRIPTION
removes `ifdiv` for now, which looks like an incomplete if statement.

This seems to fix the functionality, at least!

fixes AshWhitear/emoji-prediction-chrome#1